### PR TITLE
Respond with 404 when snip part method has wrong arity

### DIFF
--- a/lib/vanilla/renderers/base.rb
+++ b/lib/vanilla/renderers/base.rb
@@ -113,6 +113,9 @@ module Vanilla
       # Returns the raw content for the selected part of the selected snip
       def raw_content(snip, part)
         snip.__send__((part || :content).to_sym)
+      rescue ArgumentError => e
+        raise unless e.message.match(/wrong number of arguments/)
+        nil
       end
     end
   end

--- a/test/pristine_app/current_snip_test.rb
+++ b/test/pristine_app/current_snip_test.rb
@@ -71,4 +71,21 @@ context "The current_snip dynasnip" do
       assert_equal 404, page.status_code
     end
   end
+
+  context "when the requested part method of a snip has wrong arity" do
+    setup do
+      set_main_template "<layout>{current_snip}</layout>"
+      create_snip name: "test", content: "test"
+
+      visit "/test/h"
+    end
+
+    should "render an explanatory message" do
+      assert page.has_content?(%{Couldn't find part "h" for snip "test"})
+    end
+
+    should "set the response code to 404" do
+      assert_equal 404, page.status_code
+    end
+  end
 end


### PR DESCRIPTION
See https://github.com/freerange/site/issues/34.

This isn't the most elegant solution. I did start by trying to obtain an instance of the part method and then calling `Method#arity` to check it is zero, but this isn't straightforward, because `Snip` instances respond to methods which aren't actually defined i.e. via `Object#method_missing`.

I also did a bit of investigation into why the `#h` & `#html_escape` methods exist at all, given that `Soup::EmptyClass` tries to remove all methods. I'm pretty sure it's because [`ERB::Util` is included at the top-level in `lib/vanilla/renderers/erb.erb`](https://github.com/lazyatom/vanilla-rb/blob/1f1c5624d75e5072706953ce28bee8deb5b099ad/lib/vanilla/renderers/erb.rb#L2). However, I tried a few ways to reduce the scope of this module inclusion, but couldn't get anything to work.
